### PR TITLE
feat: add flexible SSH authentication with comprehensive documentation

### DIFF
--- a/scripts/ssh-disable-password-auth.sh
+++ b/scripts/ssh-disable-password-auth.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# ssh-disable-password-auth.sh - Disable SSH password authentication
+# Run this script after adding SSH keys to switch from password to key-only auth
+
+set -e
+
+echo "===== SSH Password Authentication Disabler ====="
+echo "This script will disable SSH password authentication and enable key-only auth."
+echo "Make sure you have working SSH key access before running this!"
+echo ""
+
+# Check if we're running as root
+if [ "$EUID" -ne 0 ]; then
+    echo "Error: This script must be run as root"
+    exit 1
+fi
+
+# Get the current SSH config
+SSH_CONFIG="/etc/ssh/sshd_config"
+SSH_BACKUP="/etc/ssh/sshd_config.$(date +%Y%m%d_%H%M%S).bak"
+
+# Check if password auth is currently enabled
+if grep -q "^PasswordAuthentication yes" "$SSH_CONFIG"; then
+    echo "Current status: Password authentication is ENABLED"
+else
+    echo "Current status: Password authentication is already DISABLED"
+    exit 0
+fi
+
+# Create backup
+echo "Creating backup of SSH config: $SSH_BACKUP"
+cp "$SSH_CONFIG" "$SSH_BACKUP"
+
+# Ask for confirmation
+echo ""
+echo "WARNING: This will disable password authentication for SSH!"
+echo "Make sure you can login with SSH keys before proceeding."
+echo ""
+read -p "Are you sure you want to disable password authentication? (yes/no): " CONFIRM
+
+if [ "$CONFIRM" != "yes" ]; then
+    echo "Operation cancelled."
+    exit 0
+fi
+
+# Disable password authentication
+echo "Disabling password authentication..."
+sed -i 's/^PasswordAuthentication yes/PasswordAuthentication no/' "$SSH_CONFIG"
+
+# Test SSH configuration
+echo "Testing SSH configuration..."
+if sshd -t; then
+    echo "SSH configuration is valid."
+    
+    # Restart SSH service
+    echo "Restarting SSH service..."
+    systemctl restart sshd
+    
+    echo ""
+    echo "✅ Password authentication has been disabled successfully!"
+    echo "SSH is now configured for key-only authentication."
+    echo ""
+    echo "Backup created at: $SSH_BACKUP"
+    echo "To re-enable password auth: sed -i 's/^PasswordAuthentication no/PasswordAuthentication yes/' $SSH_CONFIG && systemctl restart sshd"
+else
+    echo "❌ SSH configuration test failed!"
+    echo "Restoring backup..."
+    cp "$SSH_BACKUP" "$SSH_CONFIG"
+    echo "Backup restored. No changes were made."
+    exit 1
+fi

--- a/templates/defaults.env
+++ b/templates/defaults.env
@@ -13,6 +13,12 @@ HOSTNAME=polyserver
 SSH_PORT=2222
 BACKUP_MOUNT=/mnt/backup
 
+# SSH Security Configuration
+# If SSH_PUBLIC_KEY is provided, password authentication will be disabled
+# If left empty, password authentication will be enabled for initial setup
+# Example: SSH_PUBLIC_KEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG... your-email@example.com"
+SSH_PUBLIC_KEY=""
+
 # Deployment mode: "docker" or "baremetal"
 # - docker: Applications run in containers, nginx as reverse proxy
 # - baremetal: Applications run directly on server, nginx serves directly

--- a/templates/server-setup.sh.template
+++ b/templates/server-setup.sh.template
@@ -8,6 +8,7 @@ set -e
 USERNAME="{{DEPLOY_USER}}"                # Non-root user to create
 HOSTNAME="{{HOSTNAME}}"                   # Server hostname
 SSH_PORT="{{SSH_PORT}}"                   # Custom SSH port (more secure than default 22)
+SSH_PUBLIC_KEY="{{SSH_PUBLIC_KEY}}"       # SSH public key for deploy user
 BLOCK_DEVICE="/dev/sdb"                   # Block storage device (adjust if needed)
 BACKUP_MOUNT="{{BACKUP_MOUNT}}"           # Backup mount point
 LOGWATCH_EMAIL="{{LOGWATCH_EMAIL}}"       # Logwatch notification email
@@ -48,22 +49,60 @@ if ! id "$USERNAME" &>/dev/null; then
     useradd -m -s /bin/bash "$USERNAME"
     echo "$USERNAME:$USERNAME" | chpasswd
   else
-    adduser --gecos "" "$USERNAME"
+    # Determine if we should create user with or without password
+    if [ -n "$SSH_PUBLIC_KEY" ]; then
+      echo "SSH public key provided - creating user without password prompt"
+      useradd -m -s /bin/bash "$USERNAME"
+      # Generate a random password and immediately expire it to force key-only auth
+      TEMP_PASS=$(openssl rand -base64 32)
+      echo "$USERNAME:$TEMP_PASS" | chpasswd
+      passwd -e "$USERNAME"
+    else
+      echo "No SSH public key provided - user will be prompted to set password"
+      adduser --gecos "" "$USERNAME"
+    fi
   fi
   usermod -aG sudo "$USERNAME"
   
   # Create SSH directory for the new user
   mkdir -p /home/$USERNAME/.ssh
-  cp ~/.ssh/authorized_keys /home/$USERNAME/.ssh/ 2>/dev/null || echo "No SSH keys to copy"
-  chown -R $USERNAME:$USERNAME /home/$USERNAME/.ssh
   chmod 700 /home/$USERNAME/.ssh
-  chmod 600 /home/$USERNAME/.ssh/authorized_keys 2>/dev/null || true
+  chown $USERNAME:$USERNAME /home/$USERNAME/.ssh
+  
+  # Set up SSH key if provided
+  if [ -n "$SSH_PUBLIC_KEY" ]; then
+    echo "Setting up SSH public key for $USERNAME"
+    echo "$SSH_PUBLIC_KEY" > /home/$USERNAME/.ssh/authorized_keys
+    chmod 600 /home/$USERNAME/.ssh/authorized_keys
+    chown $USERNAME:$USERNAME /home/$USERNAME/.ssh/authorized_keys
+    echo "SSH key configured successfully"
+  else
+    # Try to copy existing keys as fallback
+    if [ -f ~/.ssh/authorized_keys ]; then
+      echo "Copying existing SSH keys from root user"
+      cp ~/.ssh/authorized_keys /home/$USERNAME/.ssh/
+      chmod 600 /home/$USERNAME/.ssh/authorized_keys
+      chown $USERNAME:$USERNAME /home/$USERNAME/.ssh/authorized_keys
+    else
+      echo "No SSH keys available - password authentication will be enabled"
+    fi
+  fi
 fi
 
 echo "===== 4. Securing SSH ====="
 if [ "$DOCKER_MODE" = "false" ]; then
     # Backup original SSH config
     cp /etc/ssh/sshd_config /etc/ssh/sshd_config.bak
+    
+    # Determine password authentication setting based on key availability
+    if [ -n "$SSH_PUBLIC_KEY" ] || [ -f /home/$USERNAME/.ssh/authorized_keys ]; then
+        PASSWORD_AUTH="no"
+        echo "SSH keys are available - disabling password authentication"
+    else
+        PASSWORD_AUTH="yes"
+        echo "No SSH keys available - enabling password authentication for initial setup"
+        echo "WARNING: Remember to add SSH keys and disable password auth later!"
+    fi
     
     # Configure SSH
     cat > /etc/ssh/sshd_config << EOF
@@ -80,7 +119,7 @@ StrictModes yes
 MaxAuthTries 3
 MaxSessions 5
 PubkeyAuthentication yes
-PasswordAuthentication no
+PasswordAuthentication $PASSWORD_AUTH
 PermitEmptyPasswords no
 ChallengeResponseAuthentication no
 UsePAM yes


### PR DESCRIPTION
- Add SSH_PUBLIC_KEY configuration option to defaults.env
- Implement conditional SSH authentication in server-setup.sh.template
- Create ssh-disable-password-auth.sh helper script for auth conversion
- Add comprehensive SSH setup documentation to README.md
- Support both key-based (recommended) and password authentication
- Include SSH key creation guide and troubleshooting section