### PR TITLE
fix: resolve Docker mode detection issue in generate-configs.sh

### DIFF
--- a/.github/workflows/test-server-hardening.yml
+++ b/.github/workflows/test-server-hardening.yml
@@ -85,9 +85,9 @@ jobs:
     - name: Test deployment mode configurations
       run: |
         echo "🐳 Testing Docker mode configuration..."
-        # Test Docker mode
+        # Test Docker mode - exclude DEPLOYMENT_MODE from defaults to avoid override
         echo "DEPLOYMENT_MODE=docker" > test-docker.env
-        cat templates/defaults.env >> test-docker.env
+        grep -v "^DEPLOYMENT_MODE=" templates/defaults.env >> test-docker.env
         ./scripts/generate-configs.sh test-docker.env test-docker-output/
         
         # Verify Docker-specific nginx configs
@@ -95,9 +95,9 @@ jobs:
         grep -q "upstream backend" test-docker-output/nginx/nginx.conf || { echo "❌ Docker mode upstream not found"; exit 1; }
         
         echo "🔧 Testing Bare Metal mode configuration..."
-        # Test Bare Metal mode
+        # Test Bare Metal mode - exclude DEPLOYMENT_MODE from defaults to avoid override
         echo "DEPLOYMENT_MODE=baremetal" > test-baremetal.env
-        cat templates/defaults.env >> test-baremetal.env
+        grep -v "^DEPLOYMENT_MODE=" templates/defaults.env >> test-baremetal.env
         ./scripts/generate-configs.sh test-baremetal.env test-baremetal-output/
         
         # Verify bare metal nginx configs

--- a/scripts/generate-configs.sh
+++ b/scripts/generate-configs.sh
@@ -37,8 +37,10 @@ mkdir -p "${OUTPUT_DIR}/unbound"
 # Load environment variables
 source "$ENV_FILE"
 
-# Check deployment mode
-DEPLOYMENT_MODE="${DEPLOYMENT_MODE:-baremetal}"
+# Check deployment mode (ensure it's set, default to baremetal if not)
+if [ -z "$DEPLOYMENT_MODE" ]; then
+    DEPLOYMENT_MODE="baremetal"
+fi
 echo "Deployment mode: $DEPLOYMENT_MODE"
 
 # Function to replace variables in a template


### PR DESCRIPTION
The CI workflow was failing because the generate-configs.sh script was incorrectly detecting deployment mode as "baremetal" even when "docker" was specified in the environment file.

Root cause: The CI workflow was appending templates/defaults.env which contains DEPLOYMENT_MODE=baremetal, overriding the test setting.

Changes:
- Fix generate-configs.sh to only set default if DEPLOYMENT_MODE is unset
- Update CI workflow to exclude DEPLOYMENT_MODE from defaults.env when creating test environment files to prevent variable override
- Ensures Docker mode generates correct nginx.conf with upstream backend