### PR TITLE
fix: comprehensive logrotate and logcheck improvements

### DIFF
--- a/templates/server-setup.sh.template
+++ b/templates/server-setup.sh.template
@@ -1884,6 +1884,7 @@ sed -i 's/^CRON_HOURLY_RUN=.*/CRON_HOURLY_RUN="false"/' /etc/logcheck/logcheck.c
 
 # Remove hourly logcheck cron job if it exists
 rm -f /etc/cron.hourly/logcheck 2>/dev/null || true
+rm -f /etc/cron.d/logcheck 2>/dev/null || true
 
 # Add ignore patterns for common application server activity
 log_message "Adding logcheck ignore patterns for UFW and common server activity..."
@@ -1909,10 +1910,29 @@ cat >> /etc/logcheck/ignore.d.server/application-server-ignore << EOF
 ^\w{3} [ :0-9]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: .*\.service: Succeeded\.$
 ^\w{3} [ :0-9]{11} [._[:alnum:]-]+ systemd\[[0-9]+\]: Started .*\.$
 
-# Normal postfix activity (for notifications)
+# Normal postfix activity (for notifications) - support both formats
 ^\w{3} [ :0-9]{11} [._[:alnum:]-]+ postfix/smtp\[[0-9]+\]: [A-F0-9]+: to=<.*>, relay=.*$
 ^\w{3} [ :0-9]{11} [._[:alnum:]-]+ postfix/cleanup\[[0-9]+\]: [A-F0-9]+: message-id=<.*>$
 ^\w{3} [ :0-9]{11} [._[:alnum:]-]+ postfix/qmgr\[[0-9]+\]: [A-F0-9]+: from=<.*>, size=[0-9]+, nrcpt=[0-9]+.*$
+^\w{3} [ :0-9]{11} [._[:alnum:]-]+ postfix\/.*\[[0-9]+\]: [A-F0-9]+: .*$
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ postfix\/.*\[[0-9]+\]: [A-F0-9]+: .*$
+
+# Suricata normal operations and restarts (if enabled)
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ suricata\[[0-9]+\]: [0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4} -- [0-9]{2}:[0-9]{2}:[0-9]{2} - <.*> - .*$
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ systemd\[[0-9]+\]: suricata\.service: .*$
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ suricatasc\[[0-9]+\]: Unable to connect to socket .*$
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ kernel: \[[0-9.]+\] device ens[0-9]+ (entered|left) promiscuous mode$
+
+# Normal security tool operations
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ chkrootkit-daily\[[0-9]+\]: sending alert to root: .*$
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ maldet: .*$
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ root: (Security configuration backup completed|Suricata rules updated successfully): .*$
+
+# SSH connection attempts and failures (expected on internet-facing servers)
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ sshd\[[0-9]+\]: (error: |Unable to negotiate with|Connection closed by|banner exchange:).*$
+
+# Kernel packet filtering messages
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ kernel: \[[0-9.]+\] af_packet: .*$
 
 # Normal PHP-FPM activity (if using PHP)
 ^\w{3} [ :0-9]{11} [._[:alnum:]-]+ php-fpm\[[0-9]+\]: .*pool [[:alnum:]]+.*$


### PR DESCRIPTION
- Fix duplicate logrotate include directive bug in bastion script
- Replace problematic logrotate.conf append with proper emergency space config
- Add comprehensive logcheck ignore patterns for Suricata, SSH, security tools
- Enhance security report with UFW statistics instead of individual blocks
- Fix audit report date format to prevent Unix epoch times
- Add persistence baseline directory creation to prevent SUID/SGID alerts
- Remove hourly logcheck cron job from both locations
- Quote date command to prevent word splitting
- Clean up duplicate system logrotate configs