### PR TITLE
feat: add interactive Suricata service configuration to prevent rule …

### DIFF
--- a/scripts/server-setup-bastion.sh
+++ b/scripts/server-setup-bastion.sh
@@ -2982,11 +2982,21 @@ vars:
     HOME_NET: "[$BASTION_IP]"
     EXTERNAL_NET: "![$BASTION_IP]"
     INTERNAL_NET: "[$INTERNAL_NETWORK]"
+    # Bastion-specific: Only SSH services, others set to any for external monitoring only
+    HTTP_SERVERS: "any"
+    SQL_SERVERS: "any"
+    DNS_SERVERS: "any"
+    MAIL_SERVERS: "any"
+    FTP_SERVERS: "any"
     
   port-groups:
     SSH_PORTS: "$SSH_PORT"
     HTTP_PORTS: "80"
     HTTPS_PORTS: "443"
+    DNS_PORTS: "53"
+    DB_PORTS: "3306,5432,1521,1433,27017"
+    MAIL_PORTS: "25,465,587,993,995"
+    FTP_PORTS: "21,990"
     
 default-rule-path: /etc/suricata/rules
 rule-files:

--- a/templates/server-setup.sh.template
+++ b/templates/server-setup.sh.template
@@ -2639,6 +2639,74 @@ if [ "$DOCKER_MODE" = "false" ]; then
     # Configure network interface
     INTERFACE=$(ip -o -4 route show to default | awk '{print $5}')
 
+    # Interactive service configuration for Suricata monitoring
+    echo "📋 Configuring Suricata network variables based on services..."
+    echo "This helps Suricata know which services to monitor and reduces false positives."
+    echo ""
+    
+    # Service detection and configuration
+    HTTP_SERVERS='$HOME_NET'
+    SQL_SERVERS='$HOME_NET'
+    DNS_SERVERS='$HOME_NET'
+    MAIL_SERVERS='$HOME_NET'
+    FTP_SERVERS='$HOME_NET'
+    
+    if [ "$TESTING_MODE" != "true" ]; then
+        echo "Will you be running web services (nginx, apache, etc.) on this server? [Y/n]"
+        read -r web_services
+        if [[ $web_services =~ ^[Nn]$ ]]; then
+            HTTP_SERVERS="any"
+            echo "  📌 HTTP monitoring set to external traffic only"
+        else
+            echo "  📌 HTTP monitoring enabled for this server"
+        fi
+        
+        echo ""
+        echo "Will you be running database services (MySQL, PostgreSQL, etc.) on this server? [Y/n]"
+        read -r db_services
+        if [[ $db_services =~ ^[Nn]$ ]]; then
+            SQL_SERVERS="any"
+            echo "  📌 Database monitoring set to external traffic only"
+        else
+            echo "  📌 Database monitoring enabled for this server"
+        fi
+        
+        echo ""
+        echo "Will you be running DNS services on this server? [y/N]"
+        read -r dns_services
+        if [[ $dns_services =~ ^[Yy]$ ]]; then
+            echo "  📌 DNS monitoring enabled for this server"
+        else
+            DNS_SERVERS="any"
+            echo "  📌 DNS monitoring set to external traffic only"
+        fi
+        
+        echo ""
+        echo "Will you be running mail services on this server? [y/N]"
+        read -r mail_services
+        if [[ $mail_services =~ ^[Yy]$ ]]; then
+            echo "  📌 Mail monitoring enabled for this server"
+        else
+            MAIL_SERVERS="any"
+            echo "  📌 Mail monitoring set to external traffic only"
+        fi
+        
+        echo ""
+        echo "Will you be running FTP services on this server? [y/N]"
+        read -r ftp_services
+        if [[ $ftp_services =~ ^[Yy]$ ]]; then
+            echo "  📌 FTP monitoring enabled for this server"
+        else
+            FTP_SERVERS="any"
+            echo "  📌 FTP monitoring set to external traffic only"
+        fi
+    else
+        echo "  📌 Testing mode: Using default service configurations"
+    fi
+    
+    echo ""
+    echo "✅ Service configuration complete. Generating Suricata config..."
+
     # Basic Suricata configuration 
     cat > /etc/suricata/suricata.yaml << EOF
 %YAML 1.1
@@ -2648,11 +2716,20 @@ vars:
   address-groups:
     HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
     EXTERNAL_NET: "!$HOME_NET"
+    HTTP_SERVERS: "$HTTP_SERVERS"
+    SQL_SERVERS: "$SQL_SERVERS"
+    DNS_SERVERS: "$DNS_SERVERS"
+    MAIL_SERVERS: "$MAIL_SERVERS"
+    FTP_SERVERS: "$FTP_SERVERS"
     
   port-groups:
     HTTP_PORTS: "80"
     HTTPS_PORTS: "443"
+    SSH_PORTS: "22"
+    DNS_PORTS: "53"
     DB_PORTS: "3306,5432,1521,1433,27017"
+    MAIL_PORTS: "25,465,587,993,995"
+    FTP_PORTS: "21,990"
     
 default-rule-path: /etc/suricata/rules
 rule-files:


### PR DESCRIPTION
…warnings

Add interactive service detection in main server template and minimal SSH-only configuration for bastion hosts to resolve Suricata rule warnings caused by missing HTTP_SERVERS and other network variables.

Main template changes:
- Interactive prompts for web, database, DNS, mail, and FTP services
- Dynamic Suricata variable configuration based on user responses
- Testing mode bypass for automated deployments
- Comprehensive port group definitions

Bastion template changes:
- Minimal SSH-focused Suricata configuration
- All non-SSH services set to "any" for external monitoring only
- Complete variable definitions to prevent ET rule disabling

This resolves the issue where Suricata was disabling 95 rules due to undefined network variables like HTTP_SERVERS, SQL_SERVERS, etc.