### PR TITLE
fix: disable shellcheck SC2016 warnings for Suricata variable assignm…

### DIFF
--- a/templates/server-setup.sh.template
+++ b/templates/server-setup.sh.template
@@ -2645,10 +2645,15 @@ if [ "$DOCKER_MODE" = "false" ]; then
     echo ""
     
     # Service detection and configuration
+    # shellcheck disable=SC2016
     HTTP_SERVERS='$HOME_NET'
+    # shellcheck disable=SC2016
     SQL_SERVERS='$HOME_NET'
+    # shellcheck disable=SC2016
     DNS_SERVERS='$HOME_NET'
+    # shellcheck disable=SC2016
     MAIL_SERVERS='$HOME_NET'
+    # shellcheck disable=SC2016
     FTP_SERVERS='$HOME_NET'
     
     if [ "$TESTING_MODE" != "true" ]; then


### PR DESCRIPTION
…ents

Add shellcheck disable comments for variables that intentionally contain literal $HOME_NET strings. These variables are used in Suricata YAML configuration where the literal text '$HOME_NET' is required, not bash variable expansion.