### PR TITLE
fix: use Origins-Pattern for unattended-upgrades on Debian

### DIFF
--- a/scripts/server-setup-bastion.sh
+++ b/scripts/server-setup-bastion.sh
@@ -2751,8 +2751,9 @@ EOF
 
 # Configure unattended-upgrades for security patches only
 cat > /etc/apt/apt.conf.d/50unattended-upgrades << EOF
-Unattended-Upgrade::Allowed-Origins {
-    "\${distro_id}:\${distro_codename}-security";
+Unattended-Upgrade::Origins-Pattern {
+    "origin=Debian,codename=\${distro_codename}-security";
+    "origin=Debian,codename=\${distro_codename},label=Debian-Security";
 };
 
 // Automatically reboot if required (at 3 AM for bastions)

--- a/templates/server-setup.sh.template
+++ b/templates/server-setup.sh.template
@@ -1942,8 +1942,9 @@ EOF
 
 # Configure unattended-upgrades for security patches only
 cat > /etc/apt/apt.conf.d/50unattended-upgrades << EOF
-Unattended-Upgrade::Allowed-Origins {
-    "\${distro_id}:\${distro_codename}-security";
+Unattended-Upgrade::Origins-Pattern {
+    "origin=Debian,codename=\${distro_codename}-security";
+    "origin=Debian,codename=\${distro_codename},label=Debian-Security";
 };
 
 // Automatically reboot if required (at 2 AM)


### PR DESCRIPTION
Replace deprecated Allowed-Origins with Origins-Pattern in 50unattended-upgrades config. The new format uses origin/codename/label matching which is the correct approach for Debian systems and ensures security updates are reliably applied.