### PR TITLE
fix: suppress Veeam sudo spam via logcheck violations.ignore.d

### DIFF
--- a/scripts/helper-fix-veeam-logcheck-spam.sh
+++ b/scripts/helper-fix-veeam-logcheck-spam.sh
@@ -3,52 +3,77 @@
 # Issue: veeam-usr-vspc-agent runs veeaminstaller via sudo every minute for health checks,
 #        triggering hourly logcheck "Security Events for sudo" emails as false positives.
 # These are legitimate Veeam VSPC agent operations and do not indicate a security incident.
+#
+# IMPORTANT: "Security Events" in logcheck come from the violations.d ruleset and are
+# ONLY suppressed by rules in /etc/logcheck/violations.ignore.d/. Rules placed in
+# ignore.d.server/ filter the "System Events" section only and have NO effect on the
+# "Security Events for sudo" report — which is why an earlier ignore.d.server rule did
+# not work. We install into violations.ignore.d/ (primary) and ignore.d.server/ (fallback).
 
 set -e
 
-IGNORE_FILE="/etc/logcheck/ignore.d.server/veeam-agent"
+VIOLATIONS_FILE="/etc/logcheck/violations.ignore.d/veeam-agent"
+SYSTEM_FILE="/etc/logcheck/ignore.d.server/veeam-agent"
+OLD_FILE="/etc/logcheck/ignore.d.server/veeam-agent"
 
 if ! command -v logcheck >/dev/null 2>&1; then
     echo "❌ logcheck is not installed. This fix is not needed."
     exit 1
 fi
 
-mkdir -p /etc/logcheck/ignore.d.server
-
-# Back up existing file if present
-if [ -f "$IGNORE_FILE" ]; then
-    cp "$IGNORE_FILE" "${IGNORE_FILE}.bak-$(date +%Y%m%d-%H%M%S)"
-    echo "✅ Backed up existing ignore file"
-fi
-
-# Write ignore rules for both traditional syslog and ISO 8601 timestamp formats.
-# Matches: sudo[PID]: veeam-* : PWD=/ ; USER=root ; COMMAND=/var/lib/veeam*
-# No TTY field because the Veeam agent runs non-interactively via systemd.
-cat > "$IGNORE_FILE" << 'EOF'
+# Ignore-rule content. Two patterns cover traditional syslog and ISO 8601 timestamps.
+# Matches: sudo[PID]: veeam-* : ... COMMAND=/var/lib/veeam*
+# No TTY field, because the Veeam agent runs non-interactively via systemd.
+# logcheck uses extended regex (egrep -i), so '/' needs no escaping.
+read -r -d '' RULES <<'EOF' || true
 # Veeam backup agent logcheck ignore rules
 # Suppress legitimate sudo invocations by the Veeam VSPC agent service.
 # The agent runs veeaminstaller every minute for health/version checks —
 # these are not security events.
 
 # Traditional syslog timestamp (e.g. "May 27 15:02:26")
-^\w{3} [ :0-9]{11} [._[:alnum:]-]+ sudo\[[0-9]+\]: veeam-[[:alnum:]_-]+ : PWD=\/ ; USER=root ; COMMAND=\/var\/lib\/veeam[[:alnum:]\/._-]+ .*$
+^\w{3} [ :0-9]{11} [._[:alnum:]-]+ sudo\[[0-9]+\]:[[:space:]]+veeam-[[:alnum:]_-]+ : .*COMMAND=/var/lib/veeam[[:alnum:]/._-]+
 
 # ISO 8601 timestamp (e.g. "2025-05-27T15:02:26.123+0200")
-^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ sudo\[[0-9]+\]: veeam-[[:alnum:]_-]+ : PWD=\/ ; USER=root ; COMMAND=\/var\/lib\/veeam[[:alnum:]\/._-]+ .*$
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[.,][0-9]+[+-][0-9]{4} [._[:alnum:]-]+ sudo\[[0-9]+\]:[[:space:]]+veeam-[[:alnum:]_-]+ : .*COMMAND=/var/lib/veeam[[:alnum:]/._-]+
 EOF
 
-chmod 640 "$IGNORE_FILE"
-chown root:logcheck "$IGNORE_FILE" 2>/dev/null || chown root:root "$IGNORE_FILE"
+install_rule() {
+    local target="$1"
+    local dir
+    dir="$(dirname "$target")"
+    mkdir -p "$dir"
 
-echo "✅ Created $IGNORE_FILE"
+    if [ -f "$target" ]; then
+        cp "$target" "${target}.bak-$(date +%Y%m%d-%H%M%S)"
+        echo "✅ Backed up existing $target"
+    fi
+
+    printf '%s\n' "$RULES" > "$target"
+    chmod 644 "$target"
+    # logcheck runs as the 'logcheck' user; make sure it can read the rule file.
+    chown root:logcheck "$target" 2>/dev/null || chown root:root "$target"
+    echo "✅ Installed $target"
+}
+
+# Primary: suppresses the "Security Events for sudo" violations report.
+install_rule "$VIOLATIONS_FILE"
+# Fallback: harmless coverage for the "System Events" section.
+install_rule "$SYSTEM_FILE"
+
 echo ""
 echo "Changes made:"
-echo "  • Veeam VSPC agent sudo events suppressed in logcheck security emails"
+echo "  • Veeam VSPC agent sudo events suppressed in logcheck SECURITY (violations) emails"
+echo "  • Same rule installed as a System Events fallback"
 echo "  • Covers both syslog and ISO 8601 log timestamp formats"
 echo "  • Only /var/lib/veeam* commands by veeam-* users are suppressed"
 echo "  • All other sudo activity continues to be reported"
 echo ""
-echo "To verify the rule works against a sample log line:"
-echo "  echo 'May 27 15:02:26 polypublisher-1 sudo[2804225]: veeam-usr-vspc-agent : PWD=/ ; USER=root ; COMMAND=/var/lib/veeamma/utils/x64/veeaminstaller --agent-version' | grep -P \"\$(grep -v '^#' $IGNORE_FILE | grep -v '^$' | head -1)\""
+echo "Verify the rule matches a real log line (should print the line):"
+echo "  echo 'May 27 15:02:26 polypublisher-1 sudo[2804225]: veeam-usr-vspc-agent : PWD=/ ; USER=root ; COMMAND=/var/lib/veeamma/utils/x64/veeaminstaller --agent-version' \\"
+echo "    | grep -E -i -f $VIOLATIONS_FILE"
 echo ""
-echo "To restore previous state: sudo rm $IGNORE_FILE"
+echo "Confirm logcheck can read the rule files (must show readable by user 'logcheck'):"
+echo "  sudo -u logcheck test -r $VIOLATIONS_FILE && echo readable || echo NOT-READABLE"
+echo ""
+echo "To restore previous state: sudo rm $VIOLATIONS_FILE $SYSTEM_FILE"


### PR DESCRIPTION
"Security Events for sudo" come from the violations.d ruleset and are only filtered by violations.ignore.d/, not ignore.d.server/, so the earlier rule had no effect. Install the ignore rule into violations.ignore.d/ (primary) with ignore.d.server/ as a fallback.

- Loosen regex to match COMMAND=/var/lib/veeam* across both syslog and ISO 8601 timestamps, regardless of TTY/PWD fields
- Add install_rule helper that backs up, writes, and fixes ownership so the logcheck user can read the rule files
- Update verification hints to use grep -E -f and a readability check