### PR TITLE
fix: suppress Veeam sudo spam by extending logcheck-sudo ruleset

### DIFF
--- a/scripts/helper-fix-veeam-logcheck-spam.sh
+++ b/scripts/helper-fix-veeam-logcheck-spam.sh
@@ -1,97 +1,80 @@
 #!/bin/bash
 # Fix: Suppress Veeam backup agent sudo events from logcheck security emails
-# Issue: veeam-usr-vspc-agent runs veeaminstaller via sudo every minute for health checks,
-#        triggering hourly logcheck "Security Events for sudo" emails as false positives.
-# These are legitimate Veeam VSPC agent operations and do not indicate a security incident.
 #
-# IMPORTANT: "Security Events" in logcheck come from the violations.d ruleset and are
-# ONLY suppressed by rules in /etc/logcheck/violations.ignore.d/. Rules placed in
-# ignore.d.server/ filter the "System Events" section only and have NO effect on the
-# "Security Events for sudo" report — which is why an earlier ignore.d.server rule did
-# not work. We install into violations.ignore.d/ (primary) and ignore.d.server/ (fallback).
+# Issue: veeam-usr-vspc-agent runs /var/lib/veeamma/utils/x64/veeaminstaller via sudo every
+#        minute for health/version checks. logcheck reports these under "Security Events for sudo",
+#        generating hourly false-positive emails across every Veeam-backed host.
+#
+# Root cause: the stock ignore rule in /etc/logcheck/violations.ignore.d/logcheck-sudo only
+#        whitelists sudo COMMANDs whose path is under /usr, /etc, /bin or /sbin
+#        (COMMAND=((/(usr|etc|bin|sbin)/|sudoedit ).*|list)$). Veeam runs from /var/lib/veeamma,
+#        so its sudo calls fall outside that whitelist and are flagged as security violations.
+#
+# Fix: extend the logcheck-sudo ignore ruleset with a veeam-scoped exception. We append to
+#      logcheck-sudo (the ruleset logcheck actually applies to the "Security Events for sudo"
+#      report) rather than a standalone violations.ignore.d file -- on these hosts a standalone
+#      file was read by run-parts but never suppressed the sudo violations report.
 
 set -e
 
-VIOLATIONS_FILE="/etc/logcheck/violations.ignore.d/veeam-agent"
-SYSTEM_FILE="/etc/logcheck/ignore.d.server/veeam-agent"
-
-# Backups MUST live outside the logcheck rule directories: logcheck reads every file
-# in violations.ignore.d/ and ignore.d.server/ as a rule, so a stray ".bak" left there
-# is parsed as a rule and (being unreadable to the logcheck user) aborts the whole run.
+SUDO_IGNORE="/etc/logcheck/violations.ignore.d/logcheck-sudo"
+# Backups MUST live outside the logcheck rule directories: logcheck lists every file in those
+# dirs as a rule, so a stray backup left there becomes noise (or an unreadable-file warning).
 BACKUP_DIR="/var/backups/logcheck"
+
+# Veeam exception, modeled on the stock logcheck-sudo rule so it slots into the same machinery.
+# Covers both syslog ("May 27 15:02:26") and ISO 8601 timestamps, optional sudo[PID], and the
+# standard "FIELD=value ; " preamble. Scoped to veeam-* users running /var/lib/veeam* commands.
+VEEAM_SUDO_RULE='^(\w{3} [ :0-9]{11}|[0-9T:.+-]{32}) [._[:alnum:]-]+ sudo(\[[0-9]+\])?:[[:space:]]+veeam-[._[:alnum:]-]+ : ((HOST|TTY|CHROOT|PWD|USER|GROUP|ENV|TSID|EXIT|SIGNAL)=[^ ;]+ ; )*COMMAND=/var/lib/veeam[^ ]*( .*)?$'
+MARKER='# PolyServer: Veeam VSPC backup agent (veeaminstaller from /var/lib/veeamma) - legitimate, not a security event'
 
 if ! command -v logcheck >/dev/null 2>&1; then
     echo "❌ logcheck is not installed. This fix is not needed."
     exit 1
 fi
 
-# Clean up backups that earlier versions of this script wrote INTO the rule directories.
-# These break logcheck ("Could not read .../veeam-agent.bak-...") — move them to BACKUP_DIR.
+if [ ! -f "$SUDO_IGNORE" ]; then
+    echo "❌ $SUDO_IGNORE not found (logcheck-database not installed?). Aborting."
+    exit 1
+fi
+
 mkdir -p "$BACKUP_DIR"
-for stray in /etc/logcheck/violations.ignore.d/veeam-agent.bak-* \
-             /etc/logcheck/ignore.d.server/veeam-agent.bak-*; do
-    [ -e "$stray" ] || continue
-    if mv -f "$stray" "$BACKUP_DIR/$(basename "$stray")" 2>/dev/null; then
-        echo "🧹 Moved stray backup out of logcheck rule dir: $stray"
-    else
-        rm -f "$stray"
+
+# Retire the earlier standalone rule files: they are not honored for the "Security Events for
+# sudo" violations report and only cause confusion.
+for stale in /etc/logcheck/violations.ignore.d/veeam-agent \
+             /etc/logcheck/ignore.d.server/veeam-agent; do
+    if [ -e "$stale" ]; then
+        mv -f "$stale" "$BACKUP_DIR/$(basename "$stale").removed-$(date +%Y%m%d-%H%M%S)" 2>/dev/null || rm -f "$stale"
+        echo "🧹 Removed non-functional standalone rule: $stale"
     fi
 done
 
-# Ignore-rule content. Two patterns cover traditional syslog and ISO 8601 timestamps.
-# Matches: sudo[PID]: veeam-* : ... COMMAND=/var/lib/veeam*
-# No TTY field, because the Veeam agent runs non-interactively via systemd.
-# logcheck uses extended regex (egrep -i), so '/' needs no escaping.
-read -r -d '' RULES <<'EOF' || true
-# Veeam backup agent logcheck ignore rules
-# Suppress legitimate sudo invocations by the Veeam VSPC agent service.
-# The agent runs veeaminstaller every minute for health/version checks —
-# these are not security events.
+# Move any stray backups earlier versions wrote INTO the rule directories out to BACKUP_DIR.
+for stray in /etc/logcheck/violations.ignore.d/veeam-agent.bak-* \
+             /etc/logcheck/ignore.d.server/veeam-agent.bak-*; do
+    [ -e "$stray" ] || continue
+    mv -f "$stray" "$BACKUP_DIR/$(basename "$stray")" 2>/dev/null || rm -f "$stray"
+done
 
-# Traditional syslog timestamp (e.g. "May 27 15:02:26")
-^\w{3} [ :0-9]{11} [._[:alnum:]-]+ sudo\[[0-9]+\]:[[:space:]]+veeam-[[:alnum:]_-]+ : .*COMMAND=/var/lib/veeam[[:alnum:]/._-]+
-
-# ISO 8601 timestamp (e.g. "2025-05-27T15:02:26.123+0200")
-^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[.,][0-9]+[+-][0-9]{4} [._[:alnum:]-]+ sudo\[[0-9]+\]:[[:space:]]+veeam-[[:alnum:]_-]+ : .*COMMAND=/var/lib/veeam[[:alnum:]/._-]+
-EOF
-
-install_rule() {
-    local target="$1"
-    local dir
-    dir="$(dirname "$target")"
-    mkdir -p "$dir"
-
-    if [ -f "$target" ]; then
-        mkdir -p "$BACKUP_DIR"
-        cp "$target" "$BACKUP_DIR/$(basename "$target").bak-$(date +%Y%m%d-%H%M%S)"
-        echo "✅ Backed up existing $target to $BACKUP_DIR"
-    fi
-
-    printf '%s\n' "$RULES" > "$target"
-    chmod 644 "$target"
-    # logcheck runs as the 'logcheck' user; make sure it can read the rule file.
-    chown root:logcheck "$target" 2>/dev/null || chown root:root "$target"
-    echo "✅ Installed $target"
-}
-
-# Primary: suppresses the "Security Events for sudo" violations report.
-install_rule "$VIOLATIONS_FILE"
-# Fallback: harmless coverage for the "System Events" section.
-install_rule "$SYSTEM_FILE"
+# Idempotently add the Veeam exception to the stock sudo ignore ruleset.
+if grep -qF "$VEEAM_SUDO_RULE" "$SUDO_IGNORE"; then
+    echo "✅ Veeam sudo ignore rule already present in $SUDO_IGNORE - nothing to do."
+else
+    cp -a "$SUDO_IGNORE" "$BACKUP_DIR/logcheck-sudo.bak-$(date +%Y%m%d-%H%M%S)"
+    echo "✅ Backed up $SUDO_IGNORE to $BACKUP_DIR"
+    printf '\n%s\n%s\n' "$MARKER" "$VEEAM_SUDO_RULE" >> "$SUDO_IGNORE"
+    echo "✅ Added Veeam sudo ignore rule to $SUDO_IGNORE"
+fi
 
 echo ""
 echo "Changes made:"
-echo "  • Veeam VSPC agent sudo events suppressed in logcheck SECURITY (violations) emails"
-echo "  • Same rule installed as a System Events fallback"
+echo "  • Veeam VSPC agent sudo events suppressed in logcheck's \"Security Events for sudo\" report"
 echo "  • Covers both syslog and ISO 8601 log timestamp formats"
-echo "  • Only /var/lib/veeam* commands by veeam-* users are suppressed"
-echo "  • All other sudo activity continues to be reported"
+echo "  • Only /var/lib/veeam* commands by veeam-* users are suppressed; all other sudo is reported"
+echo "  • Old standalone veeam-agent rule files retired to $BACKUP_DIR"
 echo ""
-echo "Verify the rule matches a real log line (should print the line):"
-echo "  echo 'May 27 15:02:26 polypublisher-1 sudo[2804225]: veeam-usr-vspc-agent : PWD=/ ; USER=root ; COMMAND=/var/lib/veeamma/utils/x64/veeaminstaller --agent-version' \\"
-echo "    | grep -E -i -f $VIOLATIONS_FILE"
+echo "Verify logcheck now suppresses the Veeam sudo events (should print 0):"
+echo "  sudo -u logcheck /usr/sbin/logcheck -o -t 2>/dev/null | grep -c veeaminstaller"
 echo ""
-echo "Confirm logcheck can read the rule files (must show readable by user 'logcheck'):"
-echo "  sudo -u logcheck test -r $VIOLATIONS_FILE && echo readable || echo NOT-READABLE"
-echo ""
-echo "To restore previous state: sudo rm $VIOLATIONS_FILE $SYSTEM_FILE"
+echo "To undo: restore the latest $BACKUP_DIR/logcheck-sudo.bak-* over $SUDO_IGNORE"

--- a/templates/server-setup.sh.template
+++ b/templates/server-setup.sh.template
@@ -2673,6 +2673,20 @@ EOF
 
 log_message "✅ Logcheck configured with application server ignore patterns"
 
+# Suppress Veeam VSPC backup agent sudo events in logcheck's "Security Events for sudo" report.
+# The agent runs /var/lib/veeamma/.../veeaminstaller via sudo every minute for health/version
+# checks. The stock violations.ignore.d/logcheck-sudo rule only whitelists sudo COMMANDs under
+# /usr,/etc,/bin,/sbin, so /var/lib/veeam* commands are flagged as security violations. Extend
+# that ruleset (idempotently) rather than adding a standalone file, which is not honored for the
+# sudo violations report. Only applies if Veeam ever runs here; harmless otherwise.
+SUDO_IGNORE="/etc/logcheck/violations.ignore.d/logcheck-sudo"
+VEEAM_SUDO_RULE='^(\w{3} [ :0-9]{11}|[0-9T:.+-]{32}) [._[:alnum:]-]+ sudo(\[[0-9]+\])?:[[:space:]]+veeam-[._[:alnum:]-]+ : ((HOST|TTY|CHROOT|PWD|USER|GROUP|ENV|TSID|EXIT|SIGNAL)=[^ ;]+ ; )*COMMAND=/var/lib/veeam[^ ]*( .*)?$'
+if [ -f "$SUDO_IGNORE" ] && ! grep -qF "$VEEAM_SUDO_RULE" "$SUDO_IGNORE" 2>/dev/null; then
+    cp -a "$SUDO_IGNORE" "/var/backups/logcheck-sudo.bak-$(date +%Y%m%d-%H%M%S)" 2>/dev/null || true
+    printf '\n%s\n%s\n' "# PolyServer: Veeam VSPC backup agent (veeaminstaller from /var/lib/veeamma) - legitimate, not a security event" "$VEEAM_SUDO_RULE" >> "$SUDO_IGNORE"
+    log_message "✅ Added Veeam sudo ignore rule to logcheck-sudo"
+fi
+
 # Configure and initialize AIDE (Advanced Intrusion Detection Environment)
 if [ "$DOCKER_MODE" = "false" ]; then
     echo "Configuring AIDE for file integrity monitoring..."


### PR DESCRIPTION
Standalone violations.ignore.d files were never honored for the "Security Events for sudo" report, so Veeam's /var/lib/veeamma/veeaminstaller sudo calls kept triggering hourly false-positive emails. The stock logcheck-sudo rule only whitelists commands under /usr,/etc,/bin,/sbin.

- Append a veeam-scoped exception directly to violations.ignore.d/logcheck-sudo, modeled on the stock rule (idempotent, syslog + ISO 8601 timestamps)
- Retire the old standalone veeam-agent rule files to /var/backups/logcheck
- Apply the same fix in server-setup.sh.template so new installs are covered