### PR TITLE
fix: suppress auditd/logind noise, fix suricata paths and threshold s…

### DIFF
--- a/scripts/server-setup-bastion.sh
+++ b/scripts/server-setup-bastion.sh
@@ -4283,6 +4283,14 @@ cat >> /etc/logcheck/ignore.d.server/bastion-ignore << EOF
 ^\w{3} [ :0-9]{11} [._[:alnum:]-]+ sh\[[0-9]+\]: mdadm: NewArray event detected on md device /dev/md
 ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ sh\[[0-9]+\]: mdadm: DeviceDisappeared event detected on md device /dev/md
 ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ sh\[[0-9]+\]: mdadm: NewArray event detected on md device /dev/md
+
+# auditd log rotation (routine maintenance, not a security event)
+^\w{3} [ :0-9]{11} [._[:alnum:]-]+ auditd\[[0-9]+\]: Audit daemon rotating log files$
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ auditd\[[0-9]+\]: Audit daemon rotating log files$
+
+# systemd-logind scheduled reboot announcements (informational, not a security event)
+^\w{3} [ :0-9]{11} [._[:alnum:]-]+ systemd-logind\[[0-9]+\]: The system will reboot at .*!$
+^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+[+-][0-9]{4} [._[:alnum:]-]+ systemd-logind\[[0-9]+\]: The system will reboot at .*!$
 EOF
 
 echo "✅ Logcheck configured for daily server-level reports (less technical than default)"
@@ -6081,7 +6089,7 @@ if [ -f /var/run/reboot-required ]; then
     
     # Send email notification
     echo "Bastion host \$(hostname) is scheduled for automatic reboot at 04:00 AM due to security updates requiring reboot." | \
-        mail -s "BASTION NOTICE: Scheduled Reboot Tonight" root
+        mail -s "\$(hostname) NOTICE: Scheduled Reboot Tonight" root
 fi
 EOF
     

--- a/templates/suricata/local.yaml.template
+++ b/templates/suricata/local.yaml.template
@@ -116,12 +116,12 @@ logging:
         level: info
 
 # Set default rule path
-default-rule-path: /etc/suricata/rules
+default-rule-path: /var/lib/suricata/rules
 
 # Load custom rules
 rule-files:
   - suricata.rules
-  - application-custom.rules
+  - /etc/suricata/rules/application-custom.rules
 
 # Application-specific rules are in application-custom.rules
 # Rules have been updated to reduce false positives:

--- a/templates/suricata/threshold.config.template
+++ b/templates/suricata/threshold.config.template
@@ -2,10 +2,10 @@
 # Reduces alert noise while maintaining security monitoring
 
 # Port scans - limit repeated alerts from same source
-suppress gen_id 1, sig_id 3000006, track by_src
+suppress gen_id 1, sig_id 3000006
 
 # Authentication attempts - don't suppress, but could limit if too noisy
-# suppress gen_id 1, sig_id 3000002, track by_src
+# suppress gen_id 1, sig_id 3000002
 
 # Unauthorized API access - don't suppress, useful for monitoring
-# suppress gen_id 1, sig_id 3000003, track by_src
+# suppress gen_id 1, sig_id 3000003


### PR DESCRIPTION
…yntax

- Add logcheck ignore rules for auditd log rotation and systemd-logind scheduled reboot announcements (both are informational, not security events)
- Use dynamic hostname in reboot notification mail subject instead of hardcoded "BASTION"
- Fix Suricata default-rule-path to use /var/lib/suricata/rules (standard Debian location)
- Reference application-custom.rules by absolute path to avoid resolution issues
- Remove invalid `track by_src` from threshold.config suppress directives