### PR TITLE
feat: forward DNS via DNS-over-TLS to avoid UDP/53 filtering and encr…

### DIFF
--- a/scripts/server-setup-bastion.sh
+++ b/scripts/server-setup-bastion.sh
@@ -878,6 +878,9 @@ if [[ ! "$ALLOWED_INTERNAL_PORTS" =~ "53" ]]; then
     ufw allow out 53/udp comment "DNS resolution UDP"
 fi
 
+# Allow DNS-over-TLS — unbound forwards all queries via TCP/853 (see forward-zone)
+ufw allow out 853/tcp comment "DNS-over-TLS to upstream resolvers"
+
 # Allow outgoing HTTP/HTTPS for updates and monitoring
 ufw allow out 80/tcp comment "HTTP updates"
 ufw allow out 443/tcp comment "HTTPS updates"
@@ -1494,6 +1497,9 @@ server:
     # (DNSSEC validation adds complexity and potential failure points)
     # If needed in future, uncomment: auto-trust-anchor-file: "/var/lib/unbound/root.key"
 
+    # CA bundle for DNS-over-TLS upstream verification
+    tls-cert-bundle: "/etc/ssl/certs/ca-certificates.crt"
+
     # Private address handling
     private-address: 192.168.0.0/16
     private-address: 172.16.0.0/12
@@ -1504,6 +1510,15 @@ server:
     
 remote-control:
     control-enable: no
+
+# Forward all queries over DNS-over-TLS (TCP/853) instead of recursing over
+# UDP/53 — hosting providers (e.g. OVH anti-DDoS) may filter outbound UDP/53,
+# which silently breaks recursion. DoT also encrypts queries.
+forward-zone:
+    name: "."
+    forward-tls-upstream: yes
+    forward-addr: 8.8.8.8@853#dns.google
+    forward-addr: 1.1.1.1@853#cloudflare-dns.com
 EOF
 
 # Create simple main unbound.conf that includes our bastion config

--- a/templates/defaults.env.example
+++ b/templates/defaults.env.example
@@ -256,9 +256,12 @@ UNBOUND_LOG_QUERIES=no
 UNBOUND_LOG_REPLIES=no
 UNBOUND_LOG_SERVFAIL=yes
 UNBOUND_LOGFILE=/var/log/unbound.log
-# Optional fallback DNS servers (enabled by default for reliability)
+# Upstream DNS servers, queried via DNS-over-TLS (TCP/853).
+# TLS names must match the server certificate (dns.google / cloudflare-dns.com).
 UNBOUND_DNS_PRIMARY=8.8.8.8
+UNBOUND_DNS_PRIMARY_TLS_NAME=dns.google
 UNBOUND_DNS_SECONDARY=1.1.1.1
+UNBOUND_DNS_SECONDARY_TLS_NAME=cloudflare-dns.com
 
 # =============================================================================
 # WEB SERVER & SECURITY CONFIGURATION

--- a/templates/unbound/local.conf.template
+++ b/templates/unbound/local.conf.template
@@ -36,6 +36,9 @@ server:
     
     # Aggressive NSEC for better performance with DNSSEC
     aggressive-nsec: yes
+
+    # CA bundle for DNS-over-TLS upstream verification
+    tls-cert-bundle: "/etc/ssl/certs/ca-certificates.crt"
     
     # Logging settings (can be disabled in production)
     log-queries: {{UNBOUND_LOG_QUERIES}}
@@ -43,10 +46,12 @@ server:
     log-servfail: {{UNBOUND_LOG_SERVFAIL}}
     logfile: "{{UNBOUND_LOGFILE}}"
 
-# Use recursive resolution with fallback forwarding for reliability
-# Fallback forwarding enabled by default for production stability
+# Forward all queries over DNS-over-TLS (TCP/853) instead of recursing/forwarding
+# over UDP/53 — hosting providers (e.g. OVH anti-DDoS) may filter outbound UDP/53,
+# which silently breaks recursion and plain forwarding. DoT also encrypts queries.
 
 forward-zone:
     name: "."
-    forward-addr: {{UNBOUND_DNS_PRIMARY}}     # Primary DNS (default: Google)
-    forward-addr: {{UNBOUND_DNS_SECONDARY}}   # Secondary DNS (default: Cloudflare)
+    forward-tls-upstream: yes
+    forward-addr: {{UNBOUND_DNS_PRIMARY}}@853#{{UNBOUND_DNS_PRIMARY_TLS_NAME}}     # Primary DNS (default: Google)
+    forward-addr: {{UNBOUND_DNS_SECONDARY}}@853#{{UNBOUND_DNS_SECONDARY_TLS_NAME}}   # Secondary DNS (default: Cloudflare)


### PR DESCRIPTION
…ypt queries

Switch unbound from plain UDP/53 forwarding/recursion to DNS-over-TLS (TCP/853) upstreams, since hosting providers (e.g. OVH anti-DDoS) may filter outbound UDP/53 and silently break resolution.

- Configure forward-zone with forward-tls-upstream and authenticated upstreams (dns.google, cloudflare-dns.com) in both the bastion setup and the unbound local.conf template
- Add tls-cert-bundle pointing at the system CA store for certificate verification
- Open outbound TCP/853 in the bastion UFW rules
- Add UNBOUND_DNS_*_TLS_NAME variables to defaults.env.example for the TLS certificate names