### PR TITLE
fix(nginx): use modern http2 directive in site templates

### DIFF
--- a/templates/nginx/sites-available/default.conf.template
+++ b/templates/nginx/sites-available/default.conf.template
@@ -121,8 +121,9 @@ server {
 
 # HTTPS configuration (uncomment when SSL certificate is available)
 # server {
-#     listen 443 ssl http2 default_server;
-#     listen [::]:443 ssl http2 default_server;
+#     listen 443 ssl default_server;
+#     listen [::]:443 ssl default_server;
+#     http2 on;
 #     server_name {{BASE_DOMAIN}};
 #
 #     root /var/www/html;

--- a/templates/nginx/sites-available/example-proxy.conf.template
+++ b/templates/nginx/sites-available/example-proxy.conf.template
@@ -97,8 +97,9 @@ server {
 
 # HTTPS configuration (uncomment when SSL certificate is available)
 # server {
-#     listen 443 ssl http2;
-#     listen [::]:443 ssl http2;
+#     listen 443 ssl;
+#     listen [::]:443 ssl;
+#     http2 on;
 #     server_name {{APPLICATION_DOMAIN}};
 #
 #     # SSL configuration


### PR DESCRIPTION
Replace the deprecated `listen ... ssl http2` syntax with a separate `http2 on;` directive in the commented-out HTTPS server blocks of the default and example-proxy site templates. The old form is deprecated since nginx 1.25.1 and emits warnings on current Debian releases.